### PR TITLE
Add delete, pause capabilities

### DIFF
--- a/concourse/types.go
+++ b/concourse/types.go
@@ -58,6 +58,7 @@ type Pipeline struct {
 	TeamName   string                 `json:"team" yaml:"team"`
 	Unpaused   bool                   `json:"unpaused" yaml:"unpaused"`
 	Exposed    bool                   `json:"exposed" yaml:"exposed"`
+	Present    string                 `json:"present" yaml:"present"`
 }
 
 type OutResponse struct {

--- a/fly/fly.go
+++ b/fly/fly.go
@@ -21,6 +21,7 @@ type Command interface {
 	SetPipeline(pipelineName string, configFilepath string, varsFilepaths []string, vars map[string]interface{}) ([]byte, error)
 	DestroyPipeline(pipelineName string) ([]byte, error)
 	UnpausePipeline(pipelineName string) ([]byte, error)
+	PausePipeline(pipelineName string) ([]byte, error)
 	ExposePipeline(pipelineName string) ([]byte, error)
 }
 
@@ -144,6 +145,12 @@ func (f command) UnpausePipeline(pipelineName string) ([]byte, error) {
 	)
 }
 
+func (f command) PausePipeline(pipelineName string) ([]byte, error) {
+	return f.run(
+		"pause-pipeline",
+		"-p", pipelineName,
+	)
+}
 func (f command) DestroyPipeline(pipelineName string) ([]byte, error) {
 	return f.run(
 		"destroy-pipeline",

--- a/out/command.go
+++ b/out/command.go
@@ -77,6 +77,25 @@ func (c *Command) Run(input concourse.OutRequest) (concourse.OutResponse, error)
 
 		c.logger.Debugf("Login successful\n")
 
+		present := true
+		if p.Present != "" {
+			present, err = strconv.ParseBool(p.Present)
+			if err != nil {
+				return concourse.OutResponse{}, err
+			}
+		}
+
+		if !present {
+			c.logger.Debugf("Destroying pipeline: %v\n", p.Name)
+
+			_, err = c.flyCommand.DestroyPipeline(p.Name)
+			if err != nil {
+				return concourse.OutResponse{}, err
+			}
+
+			continue
+		}
+
 		configFilepath := filepath.Join(c.sourcesDir, p.ConfigFile)
 
 		var varsFilepaths []string

--- a/out/command.go
+++ b/out/command.go
@@ -124,6 +124,11 @@ func (c *Command) Run(input concourse.OutRequest) (concourse.OutResponse, error)
 			if err != nil {
 				return concourse.OutResponse{}, err
 			}
+		} else {
+			_, err = c.flyCommand.PausePipeline(p.Name)
+			if err != nil {
+				return concourse.OutResponse{}, err
+			}
 		}
 	}
 	c.logger.Debugf("Setting pipelines complete\n")

--- a/out/command.go
+++ b/out/command.go
@@ -87,12 +87,12 @@ func (c *Command) Run(input concourse.OutRequest) (concourse.OutResponse, error)
 
 		if !present {
 			c.logger.Debugf("Destroying pipeline: %v\n", p.Name)
-
 			_, err = c.flyCommand.DestroyPipeline(p.Name)
 			if err != nil {
 				return concourse.OutResponse{}, err
 			}
 
+			fmt.Fprintf(os.Stderr, "pipeline '%s' destroyed\n", p.Name)
 			continue
 		}
 
@@ -107,7 +107,7 @@ func (c *Command) Run(input concourse.OutRequest) (concourse.OutResponse, error)
 		var setOutput []byte
 		setOutput, err = c.flyCommand.SetPipeline(p.Name, configFilepath, varsFilepaths, p.Vars)
 		c.logger.Debugf("pipeline '%s' set; output:\n\n%s\n", p.Name, string(setOutput))
-		fmt.Fprintf(os.Stderr, "pipeline '%s' set; output:\n\n%s\n", p.Name, string(setOutput))
+		fmt.Fprintf(os.Stderr, "pipeline '%s' set\n", p.Name)
 		if err != nil {
 			return concourse.OutResponse{}, err
 		}


### PR DESCRIPTION
relates to mode/issues#300

After upgrading to the latest `concourse-pipeline-resource`, we realized there were some features missing that we needed.

- Add a `present` param. When false, the pipeline will be destroyed.
- `unpaused` was already a param, but it didn't _pause_ a pipeline when set to false, so we added that functionality.
- Remove printing the entire pipeline config as that will print all the secrets.

(note that this is already in use in concourse, we just never merged in these changes)